### PR TITLE
Added support to use [ ] when passing in coordinate parameters on command line since bash doesn't allow ( ) to be passed in.

### DIFF
--- a/LitServe_SAM.py
+++ b/LitServe_SAM.py
@@ -60,8 +60,9 @@ class Sam_API(ls.LitAPI):
     def decode_request(self, request):
         print(request)
         try:
-            point1 = tuple(map(int, request["p1"].strip('()').split(','))) if "p1" in request else None
-            point2 = tuple(map(int, request["p2"].strip('()').split(','))) if "p2" in request else None
+            # Allow the point parameters to be (x,y) or [x,y] as well as remove whitespaces, since bash doesn't escape ()s
+            point1 = tuple(map(int, request["p1"].strip('()[] ').split(','))) if "p1" in request else None
+            point2 = tuple(map(int, request["p2"].strip('()[] ').split(','))) if "p2" in request else None
         except:
             return "Invalid input format. Please provide point p1 and p2 in format '(x,y)'"
         alpha = float(request["alpha"]) if "alpha" in request else None


### PR DESCRIPTION
Changed server to accept point arguments enclosed in []s because bash doesn't allow me to escape the () when launching it as "python ..."
I also made it strip spaces, in case someone enters a coordinate like (40, 55) -- there is a space after the comma